### PR TITLE
update >=WARN and stack trace color

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -17,9 +17,9 @@ var levelColors = {
   10: 'gray',
   20: 'gray',
   30: 'green',
-  40: 'yellow',
-  50: 'red',
-  60: 'magenta'
+  40: 'bgYellow',
+  50: 'bgRed',
+  60: 'bgRed'
 };
 
 function ConsoleStream(env) {
@@ -48,7 +48,7 @@ ConsoleStream.prototype._write = function(data, enc, callback) {
   // Error
   if (data.err) {
     var err = data.err.stack || data.err.message;
-    if (err) msg += chalk.gray(err) + '\n';
+    if (err) msg += chalk.yellow(err) + '\n';
   }
 
   if (level >= 40) {


### PR DESCRIPTION
To make them stand out more:
- use bg\* for >=WARN tags
- use yellow for stack trace

Changes to be committed:
    modified:   lib/log.js
