### PR TITLE
update test matrix to node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
 node_js:
   - "0.12"
   - "4"
-  - "5"
+  - "6"
 
 script:
   - npm run eslint


### PR DESCRIPTION
`hexo-log` will output bunches of deprecation message on node 6 when using `hexo generate`. It could due to the fact that `bunyan` uses `dtrace-provider` which relies on earlier `nan` versions. Further inspection is still needed.
