### PR TITLE
refactor: completely rewrite the logger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ cache:
     - node_modules
 
 node_js:
-  - "8"
   - "10"
-  - "node"
+  - "12"
+  - "14"
 
 script:
   - npm run eslint

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ log.info('Hello world');
 
 Option | Description | Default
 --- | --- | ---
-`debug` | Display debug message and save log to `debug.log` file. | `false`
-`silent` | Don't display message in console. | `false`
+`debug` | Display debug message. | `false`
+`silent` | Don't display any message in console. | `false`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -31,5 +31,3 @@ Option | Description | Default
 ## License
 
 MIT
-
-[bunyan]: https://github.com/trentm/node-bunyan

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![NPM version](https://badge.fury.io/js/hexo-log.svg)](https://www.npmjs.com/package/hexo-log)
 [![Coverage Status](https://coveralls.io/repos/hexojs/hexo-log/badge.svg?branch=master)](https://coveralls.io/r/hexojs/hexo-log?branch=master)
 
-Logger for Hexo, based on [bunyan] with better console output.
+Logger for Hexo.
 
 ## Installation
 
@@ -15,10 +15,10 @@ $ npm install hexo-log --save
 ## Usage
 
 ``` js
-var log = require('hexo-log')({
+const log = require('hexo-log')({
   debug: false,
   silent: false
-});
+})
 
 log.info('Hello world');
 ```
@@ -27,7 +27,6 @@ Option | Description | Default
 --- | --- | ---
 `debug` | Display debug message and save log to `debug.log` file. | `false`
 `silent` | Don't display message in console. | `false`
-`name` | Name | `hexo`
 
 ## License
 

--- a/lib/log.js
+++ b/lib/log.js
@@ -42,7 +42,7 @@ class Logger {
     this.level = INFO;
 
     if (silent) {
-      this.level = WARN;
+      this.level = FATAL + 10;
     }
 
     if (this._debug) {

--- a/lib/log.js
+++ b/lib/log.js
@@ -39,16 +39,15 @@ const console = new Console({
 class Logger {
   constructor(options = {}) {
     const silent = options.silent || false;
-    const debug = options.debug || false;
+    this._debug = options.debug || false;
 
     this.level = LEVEL.info;
-    this._debug = debug;
 
     if (silent) {
       this.level = LEVEL.warn;
     }
 
-    if (debug) {
+    if (this._debug) {
       this.level = LEVEL.trace;
     }
   }

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,98 +1,120 @@
 'use strict';
 
-const bunyan = require('hexo-bunyan');
+const { Console } = require('console');
 const chalk = require('chalk');
-const Writable = require('stream').Writable;
 
-const levelNames = {
-  10: 'TRACE',
-  20: 'DEBUG',
-  30: 'INFO ',
-  40: 'WARN ',
-  50: 'ERROR',
-  60: 'FATAL'
+const LEVEL = {
+  trace: 10,
+  debug: 20,
+  info: 30,
+  warn: 40,
+  error: 50,
+  fatal: 60
 };
 
-const levelColors = {
-  10: 'gray',
-  20: 'gray',
-  30: 'green',
-  40: 'bgYellow',
-  50: 'bgRed',
-  60: 'bgRed'
+const LEVEL_NAMES = {
+  trace: 'TRACE',
+  debug: 'DEBUG',
+  info: 'INFO ',
+  warn: 'WARN ',
+  error: 'ERROR',
+  fatal: 'FATAL'
 };
 
-function ConsoleStream(env) {
-  Writable.call(this, {objectMode: true});
-
-  this.debug = env.debug;
-}
-
-require('util').inherits(ConsoleStream, Writable);
-
-ConsoleStream.prototype._write = function(data, enc, callback) {
-  const level = data.level;
-  let msg = '';
-
-  // Time
-  if (this.debug) {
-    msg += chalk.gray(formatTime(data.time)) + ' ';
-  }
-
-  // Level
-  msg += chalk[levelColors[level]](levelNames[level]) + ' ';
-
-  // Message
-  msg += data.msg + '\n';
-
-  // Error
-  if (data.err) {
-    const err = data.err.stack || data.err.message;
-    if (err) msg += chalk.yellow(err) + '\n';
-  }
-
-  if (level >= 40) {
-    process.stderr.write(msg);
-  } else {
-    process.stdout.write(msg);
-  }
-
-  callback();
+const LEVEL_COLORS = {
+  trace: 'gray',
+  debug: 'gray',
+  info: 'green',
+  warn: 'bgYellow',
+  error: 'bgRed',
+  fatal: 'bgRed'
 };
 
-function formatTime(date) {
-  return date.toISOString().substring(11, 23);
+const console = new Console({
+  stdout: process.stdout,
+  stderr: process.stderr,
+  colorMode: false
+});
+
+class Logger {
+  constructor(options = {}) {
+    const silent = options.silent || false;
+    const debug = options.debug || false;
+
+    this.level = LEVEL.info;
+    this._debug = debug;
+
+    if (silent) {
+      this.level = LEVEL.warn;
+    }
+
+    if (debug) {
+      this.level = LEVEL.trace;
+    }
+  }
+
+  _writeDebugTimestamp(stdType = 'stdout') {
+    if (this._debug) {
+      const str = new Date().toISOString().substring(11, 23);
+      process[stdType].write(chalk[LEVEL_COLORS.debug](str + ' '));
+    }
+  }
+
+  trace(...args) {
+    if (LEVEL.trace >= this.level) {
+      this._writeDebugTimestamp('stderr');
+      process.stderr.write(chalk[LEVEL_COLORS.trace](LEVEL_NAMES.trace));
+      console.trace(...args);
+    }
+  }
+
+  debug(...args) {
+    if (LEVEL.debug >= this.level) {
+      this._writeDebugTimestamp();
+      process.stdout.write(chalk[LEVEL_COLORS.debug](LEVEL_NAMES.debug) + ' ');
+      // For Node.js 10 and higher, console.debug is an alias for console.log
+      console.debug(...args);
+    }
+  }
+
+  info(...args) {
+    if (LEVEL.info >= this.level) {
+      this._writeDebugTimestamp();
+      process.stdout.write(chalk[LEVEL_COLORS.info](LEVEL_NAMES.info) + ' ');
+      // For Node.js 10 and higher, console.info is an alias for console.log
+      console.info(...args);
+    }
+  }
+
+  warn(...args) {
+    if (LEVEL.warn >= this.level) {
+      this._writeDebugTimestamp('stderr');
+      process.stderr.write(chalk[LEVEL_COLORS.warn](LEVEL_NAMES.warn) + ' ');
+      // For Node.js 10 and higher, console.info is an alias for console.error
+      console.warn(...args);
+    }
+  }
+
+  error(...args) {
+    if (LEVEL.error >= this.level) {
+      this._writeDebugTimestamp('stderr');
+      process.stderr.write(chalk[LEVEL_COLORS.error](LEVEL_NAMES.error) + ' ');
+      console.error(...args);
+    }
+  }
+
+  fatal(...args) {
+    if (LEVEL.fatal >= this.level) {
+      this._writeDebugTimestamp('stderr');
+      process.stderr.write(chalk[LEVEL_COLORS.fatal](LEVEL_NAMES.fatal) + ' ');
+      console.error(...args);
+    }
+  }
 }
 
 function createLogger(options) {
-  options = options || {};
+  const logger = new Logger(options);
 
-  const streams = [];
-
-  if (!options.silent) {
-    streams.push({
-      type: 'raw',
-      level: options.debug ? 'trace' : 'info',
-      stream: new ConsoleStream(options)
-    });
-  }
-
-  if (options.debug) {
-    streams.push({
-      level: 'trace',
-      path: 'debug.log'
-    });
-  }
-
-  const logger = bunyan.createLogger({
-    name: options.name || 'hexo',
-    streams,
-    serializers: {
-      err: bunyan.stdSerializers.err
-    }
-  });
-
-  // Alias for logger levels
   logger.d = logger.debug;
   logger.i = logger.info;
   logger.w = logger.warn;

--- a/lib/log.js
+++ b/lib/log.js
@@ -3,31 +3,29 @@
 const { Console } = require('console');
 const chalk = require('chalk');
 
-const LEVEL = {
-  trace: 10,
-  debug: 20,
-  info: 30,
-  warn: 40,
-  error: 50,
-  fatal: 60
-};
+const TRACE = 10;
+const DEBUG = 20;
+const INFO = 30;
+const WARN = 40;
+const ERROR = 50;
+const FATAL = 60;
 
 const LEVEL_NAMES = {
-  trace: 'TRACE',
-  debug: 'DEBUG',
-  info: 'INFO ',
-  warn: 'WARN ',
-  error: 'ERROR',
-  fatal: 'FATAL'
+  10: 'TRACE',
+  20: 'DEBUG',
+  30: 'INFO ',
+  40: 'WARN ',
+  50: 'ERROR',
+  60: 'FATAL'
 };
 
 const LEVEL_COLORS = {
-  trace: 'gray',
-  debug: 'gray',
-  info: 'green',
-  warn: 'bgYellow',
-  error: 'bgRed',
-  fatal: 'bgRed'
+  10: 'gray',
+  20: 'gray',
+  30: 'green',
+  40: 'bgYellow',
+  50: 'bgRed',
+  60: 'bgRed'
 };
 
 const console = new Console({
@@ -41,73 +39,72 @@ class Logger {
     const silent = options.silent || false;
     this._debug = options.debug || false;
 
-    this.level = LEVEL.info;
+    this.level = INFO;
 
     if (silent) {
-      this.level = LEVEL.warn;
+      this.level = WARN;
     }
 
     if (this._debug) {
-      this.level = LEVEL.trace;
+      this.level = TRACE;
     }
   }
 
-  _writeDebugTimestamp(stdType = 'stdout') {
+  _writeLogOutput(level, consoleArgs) {
     if (this._debug) {
-      const str = new Date().toISOString().substring(11, 23);
-      process[stdType].write(chalk[LEVEL_COLORS.debug](str + ' '));
+      const str = new Date().toISOString().substring(11, 23) + ' ';
+
+      if (level === TRACE || level >= WARN) {
+        process.stderr.write(chalk[LEVEL_COLORS[DEBUG]](str));
+      } else {
+        process.stdout.write(chalk[LEVEL_COLORS[DEBUG]](str));
+      }
+    }
+
+    if (level >= this.level) {
+      const str = chalk[LEVEL_COLORS[level]](LEVEL_NAMES[level]) + ' ';
+      if (level === TRACE || level >= WARN) {
+        process.stderr.write(str);
+      } else {
+        process.stdout.write(str);
+      }
+
+      if (level === TRACE) {
+        console.trace(...consoleArgs);
+      } else if (level < INFO) {
+        console.debug(...consoleArgs);
+      } else if (level < WARN) {
+        console.info(...consoleArgs);
+      } else if (level < ERROR) {
+        console.warn(...consoleArgs);
+      } else {
+        console.error(...consoleArgs);
+      }
     }
   }
 
   trace(...args) {
-    if (LEVEL.trace >= this.level) {
-      this._writeDebugTimestamp('stderr');
-      process.stderr.write(chalk[LEVEL_COLORS.trace](LEVEL_NAMES.trace) + ' ');
-      console.trace(...args);
-    }
+    this._writeLogOutput(TRACE, args);
   }
 
   debug(...args) {
-    if (LEVEL.debug >= this.level) {
-      this._writeDebugTimestamp();
-      process.stdout.write(chalk[LEVEL_COLORS.debug](LEVEL_NAMES.debug) + ' ');
-      // For Node.js 10 and higher, console.debug is an alias for console.log
-      console.debug(...args);
-    }
+    this._writeLogOutput(DEBUG, args);
   }
 
   info(...args) {
-    if (LEVEL.info >= this.level) {
-      this._writeDebugTimestamp();
-      process.stdout.write(chalk[LEVEL_COLORS.info](LEVEL_NAMES.info) + ' ');
-      // For Node.js 10 and higher, console.info is an alias for console.log
-      console.info(...args);
-    }
+    this._writeLogOutput(INFO, args);
   }
 
   warn(...args) {
-    if (LEVEL.warn >= this.level) {
-      this._writeDebugTimestamp('stderr');
-      process.stderr.write(chalk[LEVEL_COLORS.warn](LEVEL_NAMES.warn) + ' ');
-      // For Node.js 10 and higher, console.info is an alias for console.error
-      console.warn(...args);
-    }
+    this._writeLogOutput(WARN, args);
   }
 
   error(...args) {
-    if (LEVEL.error >= this.level) {
-      this._writeDebugTimestamp('stderr');
-      process.stderr.write(chalk[LEVEL_COLORS.error](LEVEL_NAMES.error) + ' ');
-      console.error(...args);
-    }
+    this._writeLogOutput(ERROR, args);
   }
 
   fatal(...args) {
-    if (LEVEL.fatal >= this.level) {
-      this._writeDebugTimestamp('stderr');
-      process.stderr.write(chalk[LEVEL_COLORS.fatal](LEVEL_NAMES.fatal) + ' ');
-      console.error(...args);
-    }
+    this._writeLogOutput(FATAL, args);
   }
 }
 

--- a/lib/log.js
+++ b/lib/log.js
@@ -62,7 +62,7 @@ class Logger {
   trace(...args) {
     if (LEVEL.trace >= this.level) {
       this._writeDebugTimestamp('stderr');
-      process.stderr.write(chalk[LEVEL_COLORS.trace](LEVEL_NAMES.trace));
+      process.stderr.write(chalk[LEVEL_COLORS.trace](LEVEL_NAMES.trace) + ' ');
       console.trace(...args);
     }
   }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "hexo-bunyan": "^2.0.0",
     "chalk": "^3.0.0"
   },
   "devDependencies": {
@@ -43,6 +42,6 @@
     "sinon": "^8.0.1"
   },
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=10.13.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,12 +1,16 @@
 'use strict';
 
-const should = require('chai').should(); // eslint-disable-line
+require('chai').should();
 const rewire = require('rewire');
 const sinon = require('sinon');
 
 describe('hexo-log', () => {
   const logger = require('../lib/log');
   const loggerModule = rewire('../lib/log');
+
+  beforeEach(() => {
+    sinon.stub().reset();
+  });
 
   it('add alias for levels', () => {
     const log = logger();
@@ -16,36 +20,6 @@ describe('hexo-log', () => {
     log.w.should.eql(log.warn);
     log.e.should.eql(log.error);
     log.log.should.eql(log.info);
-  });
-
-  it('default name is hexo', () => {
-    const log = logger();
-
-    log.fields.name.should.eql('hexo');
-  });
-
-  it('options.name', () => {
-    const log = logger({ name: 'foo' });
-
-    log.fields.name.should.eql('foo');
-  });
-
-  it('level should be trace if options.debug is true', () => {
-    const log = logger({ debug: true });
-
-    log.streams[0].level.should.eql(10);
-  });
-
-  it('should add file stream if options.debug is true', () => {
-    const log = logger({ debug: true });
-
-    log.streams[1].path.should.eql('debug.log');
-  });
-
-  it('should remove console stream if options.silent is true', () => {
-    const log = logger({ silent: true });
-
-    log.streams.length.should.eql(0);
   });
 
   it('should display time if options.debug is true', () => {
@@ -66,22 +40,5 @@ describe('hexo-log', () => {
     });
 
     spy.args[0][0].should.contain(now.toISOString().substring(11, 23));
-  });
-
-  it('should print error to process.stderr stream', () => {
-    const spy = sinon.spy();
-
-    loggerModule.__with__({
-      process: {
-        stderr: {
-          write: spy
-        }
-      }
-    })(() => {
-      const log = loggerModule();
-      log.error('test');
-    });
-
-    spy.calledOnce.should.be.true;
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -23,8 +23,9 @@ const fakeProcess = {
   }
 };
 
+const logger = require('../lib/log');
+
 describe('hexo-log', () => {
-  const logger = require('../lib/log');
   let loggerModule;
 
   beforeEach(() => {
@@ -43,7 +44,7 @@ describe('hexo-log', () => {
   });
 
   it('trace - should call console.trace', () => {
-    const spy = sinon.fake();
+    const spy = sinon.spy();
     loggerModule.__set__('console.trace', spy);
 
     loggerModule.__with__(fakeProcess)(() => {
@@ -55,7 +56,7 @@ describe('hexo-log', () => {
   });
 
   it('debug - should call console.debug', () => {
-    const spy = sinon.fake();
+    const spy = sinon.spy();
     loggerModule.__set__('console.debug', spy);
 
     loggerModule.__with__(fakeProcess)(() => {
@@ -67,7 +68,7 @@ describe('hexo-log', () => {
   });
 
   it('info - should call console.info', () => {
-    const spy = sinon.fake();
+    const spy = sinon.spy();
     loggerModule.__set__('console.info', spy);
 
     loggerModule.__with__(fakeProcess)(() => {
@@ -79,7 +80,7 @@ describe('hexo-log', () => {
   });
 
   it('warn - should call console.warn', () => {
-    const spy = sinon.fake();
+    const spy = sinon.spy();
     loggerModule.__set__('console.warn', spy);
 
     loggerModule.__with__(fakeProcess)(() => {
@@ -91,7 +92,7 @@ describe('hexo-log', () => {
   });
 
   it('error - should call console.error', () => {
-    const spy = sinon.fake();
+    const spy = sinon.spy();
     loggerModule.__set__('console.error', spy);
 
     loggerModule.__with__(fakeProcess)(() => {
@@ -103,7 +104,7 @@ describe('hexo-log', () => {
   });
 
   it('fatal - should call console.error', () => {
-    const spy = sinon.fake();
+    const spy = sinon.spy();
     loggerModule.__set__('console.error', spy);
 
     loggerModule.__with__(fakeProcess)(() => {
@@ -137,11 +138,11 @@ describe('hexo-log', () => {
   });
 
   it('options.silent - should ignore those level lower than warn', () => {
-    const consoleTraceSpy = sinon.fake();
-    const consoleDebugSpy = sinon.fake();
-    const consoleInfoSpy = sinon.fake();
-    const consoleWarnSpy = sinon.fake();
-    const consoleErrorSpy = sinon.fake();
+    const consoleTraceSpy = sinon.spy();
+    const consoleDebugSpy = sinon.spy();
+    const consoleInfoSpy = sinon.spy();
+    const consoleWarnSpy = sinon.spy();
+    const consoleErrorSpy = sinon.spy();
 
     loggerModule.__set__('console.trace', consoleTraceSpy);
     loggerModule.__set__('console.debug', consoleDebugSpy);
@@ -164,5 +165,43 @@ describe('hexo-log', () => {
     consoleInfoSpy.called.should.be.false;
     consoleWarnSpy.calledOnce.should.be.true;
     consoleErrorSpy.calledTwice.should.be.true;
+  });
+});
+
+describe('hexo-log example', () => {
+  it('log.trace()', () => {
+    const log = logger({ debug: true });
+
+    log.trace('Hello, World!');
+  });
+
+  it('log.debug()', () => {
+    const log = logger({ debug: true });
+
+    log.debug('Hello, World!');
+  });
+
+  it('log.info()', () => {
+    const log = logger({ debug: true });
+
+    log.info('Hello, World!');
+  });
+
+  it('log.warn()', () => {
+    const log = logger({ debug: true });
+
+    log.warn('Hello, World!');
+  });
+
+  it('log.error()', () => {
+    const log = logger({ debug: true });
+
+    log.error('Hello, World!');
+  });
+
+  it('log.fatal()', () => {
+    const log = logger({ debug: true });
+
+    log.fatal('Hello, World!');
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -281,7 +281,7 @@ describe('hexo-log', () => {
     spy.args[0][0].should.contain(now.toISOString().substring(11, 23));
   });
 
-  it('options.silent - should ignore those level lower than warn', () => {
+  it('options.silent - should not display anything', () => {
     const consoleTraceSpy = sinon.spy();
     const consoleDebugSpy = sinon.spy();
     const consoleInfoSpy = sinon.spy();
@@ -307,8 +307,8 @@ describe('hexo-log', () => {
     consoleTraceSpy.called.should.be.false;
     consoleDebugSpy.called.should.be.false;
     consoleInfoSpy.called.should.be.false;
-    consoleWarnSpy.calledOnce.should.be.true;
-    consoleErrorSpy.calledTwice.should.be.true;
+    consoleWarnSpy.calledOnce.should.be.false;
+    consoleErrorSpy.calledTwice.should.be.false;
   });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -55,6 +55,30 @@ describe('hexo-log', () => {
     spy.called.should.be.true;
   });
 
+  it('trace - with stderr and no stdout', () => {
+    const stdoutSpy = sinon.spy();
+    const stderrSpy = sinon.spy();
+
+    loggerModule.__set__('console', fakeConsole);
+
+    loggerModule.__with__({
+      process: {
+        stderr: {
+          write: stderrSpy
+        },
+        stdout: {
+          write: stdoutSpy
+        }
+      }
+    })(() => {
+      const log = loggerModule({ debug: true });
+      log.trace('test');
+    });
+
+    stderrSpy.called.should.be.true;
+    stdoutSpy.called.should.be.false;
+  });
+
   it('debug - should call console.debug', () => {
     const spy = sinon.spy();
     loggerModule.__set__('console.debug', spy);
@@ -65,6 +89,30 @@ describe('hexo-log', () => {
     });
 
     spy.called.should.be.true;
+  });
+
+  it('debug - with stdout and no stderr', () => {
+    const stdoutSpy = sinon.spy();
+    const stderrSpy = sinon.spy();
+
+    loggerModule.__set__('console', fakeConsole);
+
+    loggerModule.__with__({
+      process: {
+        stderr: {
+          write: stderrSpy
+        },
+        stdout: {
+          write: stdoutSpy
+        }
+      }
+    })(() => {
+      const log = loggerModule({ debug: true });
+      log.debug('test');
+    });
+
+    stderrSpy.called.should.be.false;
+    stdoutSpy.called.should.be.true;
   });
 
   it('info - should call console.info', () => {
@@ -79,6 +127,30 @@ describe('hexo-log', () => {
     spy.called.should.be.true;
   });
 
+  it('info - with stdout and no stderr', () => {
+    const stdoutSpy = sinon.spy();
+    const stderrSpy = sinon.spy();
+
+    loggerModule.__set__('console', fakeConsole);
+
+    loggerModule.__with__({
+      process: {
+        stderr: {
+          write: stderrSpy
+        },
+        stdout: {
+          write: stdoutSpy
+        }
+      }
+    })(() => {
+      const log = loggerModule({ debug: true });
+      log.info('test');
+    });
+
+    stderrSpy.called.should.be.false;
+    stdoutSpy.called.should.be.true;
+  });
+
   it('warn - should call console.warn', () => {
     const spy = sinon.spy();
     loggerModule.__set__('console.warn', spy);
@@ -89,6 +161,30 @@ describe('hexo-log', () => {
     });
 
     spy.called.should.be.true;
+  });
+
+  it('warn - with stderr and no stdout', () => {
+    const stdoutSpy = sinon.spy();
+    const stderrSpy = sinon.spy();
+
+    loggerModule.__set__('console', fakeConsole);
+
+    loggerModule.__with__({
+      process: {
+        stderr: {
+          write: stderrSpy
+        },
+        stdout: {
+          write: stdoutSpy
+        }
+      }
+    })(() => {
+      const log = loggerModule({ debug: true });
+      log.warn('test');
+    });
+
+    stderrSpy.called.should.be.true;
+    stdoutSpy.called.should.be.false;
   });
 
   it('error - should call console.error', () => {
@@ -103,6 +199,30 @@ describe('hexo-log', () => {
     spy.called.should.be.true;
   });
 
+  it('error - with stderr and no stdout', () => {
+    const stdoutSpy = sinon.spy();
+    const stderrSpy = sinon.spy();
+
+    loggerModule.__set__('console', fakeConsole);
+
+    loggerModule.__with__({
+      process: {
+        stderr: {
+          write: stderrSpy
+        },
+        stdout: {
+          write: stdoutSpy
+        }
+      }
+    })(() => {
+      const log = loggerModule({ debug: true });
+      log.error('test');
+    });
+
+    stderrSpy.called.should.be.true;
+    stdoutSpy.called.should.be.false;
+  });
+
   it('fatal - should call console.error', () => {
     const spy = sinon.spy();
     loggerModule.__set__('console.error', spy);
@@ -113,6 +233,30 @@ describe('hexo-log', () => {
     });
 
     spy.called.should.be.true;
+  });
+
+  it('fatal - with stderr and no stdout', () => {
+    const stdoutSpy = sinon.spy();
+    const stderrSpy = sinon.spy();
+
+    loggerModule.__set__('console', fakeConsole);
+
+    loggerModule.__with__({
+      process: {
+        stderr: {
+          write: stderrSpy
+        },
+        stdout: {
+          write: stdoutSpy
+        }
+      }
+    })(() => {
+      const log = loggerModule({ debug: true });
+      log.fatal('test');
+    });
+
+    stderrSpy.called.should.be.true;
+    stdoutSpy.called.should.be.false;
   });
 
   it('options.debug - should display time', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -4,12 +4,32 @@ require('chai').should();
 const rewire = require('rewire');
 const sinon = require('sinon');
 
+const noop = () => {};
+const fakeConsole = {
+  trace: noop,
+  debug: noop,
+  info: noop,
+  warn: noop,
+  error: noop
+};
+const fakeProcess = {
+  process: {
+    stderr: {
+      write: noop
+    },
+    stdout: {
+      write: noop
+    }
+  }
+};
+
 describe('hexo-log', () => {
   const logger = require('../lib/log');
-  const loggerModule = rewire('../lib/log');
+  let loggerModule;
 
   beforeEach(() => {
-    sinon.stub().reset();
+    sinon.restore();
+    loggerModule = rewire('../lib/log');
   });
 
   it('add alias for levels', () => {
@@ -22,9 +42,83 @@ describe('hexo-log', () => {
     log.log.should.eql(log.info);
   });
 
-  it('should display time if options.debug is true', () => {
+  it('trace - should call console.trace', () => {
+    const spy = sinon.fake();
+    loggerModule.__set__('console.trace', spy);
+
+    loggerModule.__with__(fakeProcess)(() => {
+      const log = loggerModule({ debug: true });
+      log.trace('test');
+    });
+
+    spy.called.should.be.true;
+  });
+
+  it('debug - should call console.debug', () => {
+    const spy = sinon.fake();
+    loggerModule.__set__('console.debug', spy);
+
+    loggerModule.__with__(fakeProcess)(() => {
+      const log = loggerModule({ debug: true });
+      log.debug('test');
+    });
+
+    spy.called.should.be.true;
+  });
+
+  it('info - should call console.info', () => {
+    const spy = sinon.fake();
+    loggerModule.__set__('console.info', spy);
+
+    loggerModule.__with__(fakeProcess)(() => {
+      const log = loggerModule({ debug: true });
+      log.info('test');
+    });
+
+    spy.called.should.be.true;
+  });
+
+  it('warn - should call console.warn', () => {
+    const spy = sinon.fake();
+    loggerModule.__set__('console.warn', spy);
+
+    loggerModule.__with__(fakeProcess)(() => {
+      const log = loggerModule({ debug: true });
+      log.warn('test');
+    });
+
+    spy.called.should.be.true;
+  });
+
+  it('error - should call console.error', () => {
+    const spy = sinon.fake();
+    loggerModule.__set__('console.error', spy);
+
+    loggerModule.__with__(fakeProcess)(() => {
+      const log = loggerModule({ debug: true });
+      log.error('test');
+    });
+
+    spy.called.should.be.true;
+  });
+
+  it('fatal - should call console.error', () => {
+    const spy = sinon.fake();
+    loggerModule.__set__('console.error', spy);
+
+    loggerModule.__with__(fakeProcess)(() => {
+      const log = loggerModule({ debug: true });
+      log.fatal('test');
+    });
+
+    spy.called.should.be.true;
+  });
+
+  it('options.debug - should display time', () => {
     const spy = sinon.spy();
     const now = new Date();
+
+    loggerModule.__set__('console', fakeConsole);
 
     loggerModule.__with__({
       process: {
@@ -40,5 +134,35 @@ describe('hexo-log', () => {
     });
 
     spy.args[0][0].should.contain(now.toISOString().substring(11, 23));
+  });
+
+  it('options.silent - should ignore those level lower than warn', () => {
+    const consoleTraceSpy = sinon.fake();
+    const consoleDebugSpy = sinon.fake();
+    const consoleInfoSpy = sinon.fake();
+    const consoleWarnSpy = sinon.fake();
+    const consoleErrorSpy = sinon.fake();
+
+    loggerModule.__set__('console.trace', consoleTraceSpy);
+    loggerModule.__set__('console.debug', consoleDebugSpy);
+    loggerModule.__set__('console.info', consoleInfoSpy);
+    loggerModule.__set__('console.warn', consoleWarnSpy);
+    loggerModule.__set__('console.error', consoleErrorSpy);
+
+    loggerModule.__with__(fakeProcess)(() => {
+      const log = loggerModule({ silent: true });
+      log.trace('test');
+      log.debug('test');
+      log.info('test');
+      log.warn('test');
+      log.error('test');
+      log.fatal('test');
+    });
+
+    consoleTraceSpy.called.should.be.false;
+    consoleDebugSpy.called.should.be.false;
+    consoleInfoSpy.called.should.be.false;
+    consoleWarnSpy.calledOnce.should.be.true;
+    consoleErrorSpy.calledTwice.should.be.true;
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -313,39 +313,35 @@ describe('hexo-log', () => {
 });
 
 describe('hexo-log example', () => {
+  const log = logger({ debug: true });
+  const log2 = logger();
   it('log.trace()', () => {
-    const log = logger({ debug: true });
-
     log.trace('Hello, World!');
+    log2.trace('Hello, World!');
   });
 
   it('log.debug()', () => {
-    const log = logger({ debug: true });
-
     log.debug('Hello, World!');
+    log2.debug('Hello, World!');
   });
 
   it('log.info()', () => {
-    const log = logger({ debug: true });
-
     log.info('Hello, World!');
+    log2.info('Hello, World!');
   });
 
   it('log.warn()', () => {
-    const log = logger({ debug: true });
-
     log.warn('Hello, World!');
+    log2.warn('Hello, World!');
   });
 
   it('log.error()', () => {
-    const log = logger({ debug: true });
-
     log.error('Hello, World!');
+    log2.error('Hello, World!');
   });
 
   it('log.fatal()', () => {
-    const log = logger({ debug: true });
-
     log.fatal('Hello, World!');
+    log2.fatal('Hello, World!');
   });
 });


### PR DESCRIPTION
Since hexo-bunyan is too heavy and hard to maintained, I have rewritten a new logger with nearly the same behavior (except `debug.log` file output). ~~So far the unit test is not finished yet.~~ Coverage is now 100%.