### PR TITLE
chore: fix npm script for send coverage report

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "eslint": "eslint .",
     "test": "mocha test/index.js",
-    "test-cov": "nyc npm run test"
+    "test-cov": "nyc --reporter=lcovonly npm run test"
   },
   "directories": {
     "lib": "./lib"


### PR DESCRIPTION
I made mistake in #53 
The coverage report is not sending to coveralls.

This PR is fix it.
