### PR TITLE
refactor: use picocolors instead of nanocolors

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Console } = require('console');
-const nanocolors = require('nanocolors');
+const picocolors = require('picocolors');
 
 const TRACE = 10;
 const DEBUG = 20;
@@ -55,14 +55,14 @@ class Logger {
       const str = new Date().toISOString().substring(11, 23) + ' ';
 
       if (level === TRACE || level >= WARN) {
-        process.stderr.write(nanocolors[LEVEL_COLORS[DEBUG]](str));
+        process.stderr.write(picocolors[LEVEL_COLORS[DEBUG]](str));
       } else {
-        process.stdout.write(nanocolors[LEVEL_COLORS[DEBUG]](str));
+        process.stdout.write(picocolors[LEVEL_COLORS[DEBUG]](str));
       }
     }
 
     if (level >= this.level) {
-      const str = nanocolors[LEVEL_COLORS[level]](LEVEL_NAMES[level]) + ' ';
+      const str = picocolors[LEVEL_COLORS[level]](LEVEL_NAMES[level]) + ' ';
       if (level === TRACE || level >= WARN) {
         process.stderr.write(str);
       } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
-        "nanocolors": "^0.2.12"
+        "picocolors": "^1.0.0"
       },
       "devDependencies": {
         "chai": "^4.1.2",
@@ -2956,11 +2956,6 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
-    "node_modules/nanocolors": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.12.tgz",
-      "integrity": "sha512-SFNdALvzW+rVlzqexid6epYdt8H9Zol7xDoQarioEFcFN0JHo4CYNztAxmtfgGTVRCmFlEOqqhBpoFGKqSAMug=="
-    },
     "node_modules/nanoid": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
@@ -3380,6 +3375,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/picomatch": {
       "version": "2.3.0",
@@ -6844,11 +6844,6 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
-    "nanocolors": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.12.tgz",
-      "integrity": "sha512-SFNdALvzW+rVlzqexid6epYdt8H9Zol7xDoQarioEFcFN0JHo4CYNztAxmtfgGTVRCmFlEOqqhBpoFGKqSAMug=="
-    },
     "nanoid": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
@@ -7174,6 +7169,11 @@
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true
+    },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "picomatch": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -28,9 +28,6 @@
     "Abner Chou <hi@abnerchou.me> (http://abnerchou.me)"
   ],
   "license": "MIT",
-  "dependencies": {
-    "nanocolors": "^0.2.12"
-  },
   "devDependencies": {
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
@@ -43,5 +40,8 @@
   },
   "engines": {
     "node": ">=12.4.0"
+  },
+  "dependencies": {
+    "picocolors": "^1.0.0"
   }
 }


### PR DESCRIPTION
nanocolors is deprecated. picocolors should be used instead.