### PR TITLE
chore: fix typescript settings for publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "lib": "./lib"
   },
   "files": [
-    "lib/"
+    "dist/**"
   ],
+  "types": "./dist/log.d.ts",
   "repository": "hexojs/hexo-log",
   "homepage": "https://hexo.io/",
   "keywords": [


### PR DESCRIPTION
Sorry, I made some mistake. We have to merge this PR before release `v4.0.0` #125 

## Before fix

```sh
$ npm publish --dry-run
npm WARN config global `--global`, `--local` are deprecated. Use `--location=global` instead.
npm notice 
npm notice 📦  hexo-log@4.0.0
npm notice === Tarball Contents ===
npm notice 1.1kB LICENSE
npm notice 877B  README.md
npm notice 4.0kB dist/log.js
npm notice 3.2kB lib/log.ts
npm notice 1.4kB package.json
npm notice === Tarball Details ===
npm notice name:          hexo-log
npm notice version:       4.0.0
npm notice filename:      hexo-log-4.0.0.tgz
npm notice package size:  3.3 kB
npm notice unpacked size: 10.5 kB
npm notice shasum:        2845040d36e9a6b2ef8ad402c9d1a8f987cca78a
npm notice integrity:     sha512-FqUD2oBgbuhAg[...]rh0LCuYC+fvQA==
npm notice total files:   5
npm notice
+ hexo-log@4.0.0
```

## After fix

```sh
npm publish --dry-run
npm WARN config global `--global`, `--local` are deprecated. Use `--location=global` instead.
npm notice 
npm notice 📦  hexo-log@4.0.0
npm notice === Tarball Contents ===
npm notice 1.1kB LICENSE
npm notice 877B  README.md
npm notice 753B  dist/log.d.ts
npm notice 4.0kB dist/log.js
npm notice 3.8kB dist/log.js.map
npm notice 1.4kB package.json
npm notice === Tarball Details ===
npm notice name:          hexo-log
npm notice version:       4.0.0
npm notice filename:      hexo-log-4.0.0.tgz
npm notice package size:  3.8 kB
npm notice unpacked size: 11.8 kB
npm notice shasum:        c38266562d0e987608f976d712c2742e550d7c0e
npm notice integrity:     sha512-ksaU160mzE2ON[...]XR+upMuEHLBDg==
npm notice total files:   6
npm notice
+ hexo-log@4.0.0
```