### PR TITLE
fix: `Options` argument from required to optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,22 @@ const log = require('hexo-log')({
   debug: false,
   silent: false
 });
+log.info('Hello world');
 
 // v4.x.x
 const log = require('hexo-log').default({
   debug: false,
   silent: false
 });
+log.info('Hello world');
 
+// v4.x.x (ES Module)
+import { logger } from 'hexo-log';
+
+const log = logger({
+  debug: false,
+  silent: false
+});
 log.info('Hello world');
 ```
 

--- a/lib/log.ts
+++ b/lib/log.ts
@@ -149,7 +149,7 @@ class Logger {
   }
 }
 
-export default function createLogger(options: Options) {
+export default function createLogger(options: Options = {}) {
   const logger = new Logger(options);
 
   logger.d = logger.debug;
@@ -161,4 +161,4 @@ export default function createLogger(options: Options) {
   return logger;
 }
 
-export const logger = (option: Options) => createLogger(option);
+export const logger = (option: Options = {}) => createLogger(option);


### PR DESCRIPTION
As is the title.

## What is a problem?

Current `v4.0.0` must be pass a `Options` argument when call `logger`.
IMHO `Options` should be optional.

---

Thank you.