### PR TITLE
chore: cast type `ConsoleArgs` to `any[]`

### DIFF
--- a/lib/log.ts
+++ b/lib/log.ts
@@ -37,7 +37,7 @@ interface Options {
   silent?: boolean
 }
 
-type ConsoleArgs = [object | string, ...any[]];
+type ConsoleArgs = any[];
 
 type writeLogF = (...args: ConsoleArgs) => void;
 

--- a/lib/log.ts
+++ b/lib/log.ts
@@ -37,7 +37,7 @@ interface Options {
   silent?: boolean
 }
 
-type ConsoleArgs = [object | string, ...string[]];
+type ConsoleArgs = [object | string, ...any[]];
 
 type writeLogF = (...args: ConsoleArgs) => void;
 


### PR DESCRIPTION
fixed for logging an `object` in typescript.

```log
type non string is not assignable to type 'string'.ts(2322)
```

example
```js
hexo.log.info('logname', { prop: 'value' });
```

error
```log
Type '{ prop: string }' is not assignable to type 'string'. ts(2345)
```