### PR TITLE
feat: add ESM/CJS dual build support and enhance logger output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ tmp/
 .nyc_output/
 dist
 package-lock.json
+yarn.lock
+*.ignore

--- a/lib/log.ts
+++ b/lib/log.ts
@@ -26,6 +26,23 @@ const LEVEL_COLORS = {
   60: 'bgRed'
 };
 
+function applyColor(str: string, color: string) {
+  switch (color) {
+    case 'gray':
+      return picocolors.gray(str);
+    case 'green':
+      return picocolors.green(str);
+    case 'bgYellow':
+      return picocolors.bgYellow(str);
+    case 'bgRed':
+      return picocolors.bgRed(str);
+    case 'yellow':
+      return picocolors.yellow(str);
+    default:
+      return str;
+  }
+}
+
 const console = new Console({
   stdout: process.stdout,
   stderr: process.stderr,
@@ -33,8 +50,8 @@ const console = new Console({
 });
 
 interface Options {
-  debug?: boolean,
-  silent?: boolean
+  debug?: boolean;
+  silent?: boolean;
 }
 
 type ConsoleArgs = any[];
@@ -42,7 +59,6 @@ type ConsoleArgs = any[];
 type writeLogF = (...args: ConsoleArgs) => void;
 
 class Logger {
-
   _silent: boolean;
   _debug: boolean;
   level: number;
@@ -52,10 +68,7 @@ class Logger {
   e: writeLogF;
   log: writeLogF;
 
-  constructor({
-    debug = false,
-    silent = false
-  }: Options = {}) {
+  constructor({ debug = false, silent = false }: Options = {}) {
     this._silent = silent || false;
     this._debug = debug || false;
 
@@ -81,20 +94,20 @@ class Logger {
 
     if (this._debug) {
       const str = new Date().toISOString().substring(11, 23) + ' ';
-
+      const coloredStr = applyColor(str, LEVEL_COLORS[DEBUG]);
       if (level === TRACE || level >= WARN) {
-        process.stderr.write(picocolors[LEVEL_COLORS[DEBUG]](str));
+        process.stderr.write(coloredStr);
       } else {
-        process.stdout.write(picocolors[LEVEL_COLORS[DEBUG]](str));
+        process.stdout.write(coloredStr);
       }
     }
 
     if (level >= this.level) {
-      const str = picocolors[LEVEL_COLORS[level]](LEVEL_NAMES[level]) + ' ';
+      const levelStr = applyColor(LEVEL_NAMES[level], LEVEL_COLORS[level]) + ' ';
       if (level === TRACE || level >= WARN) {
-        process.stderr.write(str);
+        process.stderr.write(levelStr);
       } else {
-        process.stdout.write(str);
+        process.stdout.write(levelStr);
       }
 
       if (level === TRACE) {
@@ -112,12 +125,11 @@ class Logger {
       if (errArg) {
         const err = errArg.stack || errArg.message;
         if (err) {
-          const str = picocolors.yellow(err) + '\n';
-
+          const errStr = applyColor(err, 'yellow') + '\n';
           if (level === TRACE || level >= WARN) {
-            process.stderr.write(str);
+            process.stderr.write(errStr);
           } else {
-            process.stdout.write(str);
+            process.stdout.write(errStr);
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -2,19 +2,33 @@
   "name": "hexo-log",
   "version": "4.1.0",
   "description": "Logger for Hexo",
-  "main": "dist/log.js",
+  "type": "module",
+  "main": "dist/cjs/log.js",
+  "module": "dist/esm/log.js",
+  "types": "dist/esm/log.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/log.js",
+      "require": "./dist/cjs/log.js",
+      "types": "./dist/esm/log.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
-    "prepublish ": "npm run clean && npm run build",
-    "build": "tsc -b",
-    "clean": "tsc -b --clean",
+    "prepublish": "npm run clean && npm run build",
+    "build-cjs": "tsc -p tsconfig.cjs.json",
+    "build-esm": "tsc -p tsconfig.esm.json",
+    "build": "npm run build-cjs && npm run build-esm",
+    "clean": "npx -y rimraf dist tmp",
     "eslint": "eslint .",
-    "test": "mocha test/*.spec.ts",
-    "test-cov": "nyc --reporter=lcovonly npm test"
+    "test": "mocha --loader=ts-node/esm test/*.spec.ts",
+    "test-cov": "nyc --reporter=lcovonly npm test",
+    "lint": "eslint test lib",
+    "lint-fix": "npm run lint -- --fix"
   },
   "files": [
     "dist/**"
   ],
-  "types": "./dist/log.d.ts",
   "repository": "hexojs/hexo-log",
   "homepage": "https://hexo.io/",
   "keywords": [
@@ -48,6 +62,6 @@
     "node": ">=14"
   },
   "dependencies": {
-    "picocolors": "^1.0.0"
+    "picocolors": "^1.1.1"
   }
 }

--- a/test/log.spec.ts
+++ b/test/log.spec.ts
@@ -1,7 +1,11 @@
-
+import { fileURLToPath } from 'url';
+import path from 'path';
 import rewire from 'rewire';
 import sinon from 'sinon';
-import { logger } from '../lib/log';
+import { logger } from '../lib/log.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const noop = () => {};
 const fakeConsole = {
@@ -28,7 +32,8 @@ describe('hexo-log', () => {
 
   beforeEach(() => {
     sinon.restore();
-    loggerModule = rewire('../lib/log');
+    const cjsModule = path.join(__dirname, '../dist/cjs/log.js');
+    loggerModule = rewire(cjsModule);
   });
 
   it('add alias for levels', () => {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ES2020",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "lib": ["ES2020", "ES2019"],
+    "rootDir": "lib"
+  },
+  "include": ["lib/**.ts", "./*.json"],
+  "exclude": ["node_modules"]
+}

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "lib": ["ES2020"],
+    "outDir": "dist/cjs"
+  }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "outDir": "dist/esm",
+    "allowSyntheticDefaultImports": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,15 @@
 {
+  // TypeScript configuration for IDE and mocha support only. Not used for build.
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es6",
-    "sourceMap": true,
-    "outDir": "dist",
-    "declaration": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
     "esModuleInterop": true,
-    "types": ["node"]
+    "target": "ES2022",
+    "outDir": "tmp/dist",
+    "types": ["node", "mocha"]
   },
   "include": ["lib/log.ts"],
   "exclude": ["node_modules"],


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo!
-->

## check list

- [ ] Add test cases for the changes.
- [x] Passed the CI test.

## Description 

This PR introduces comprehensive enhancements to the build process and logger system:

- **Dual Build Support**: Added separate `tsconfig.cjs.json` and `tsconfig.esm.json` for CommonJS and ESM builds.
- **Package Exports**: Updated `package.json` to use `"type": "module"` and define proper `exports` fields for both ESM and CJS consumers.
- **Logger Improvements**: Centralized ANSI color formatting using a new `applyColor()` utility, simplifying and unifying logger output.
- **ESM Test Compatibility**: Switched test runner to `ts-node/esm` to fully support ESM module syntax in test files.
- **Git Hygiene**:
  - Updated `.gitignore` to ignore `yarn.lock` and wildcard `*.ignore` patterns.
  - Added `tsconfig.base.json` to share base settings across build targets.
- **Code Cleanups**: Refactored the logger constructor and streamlined logging logic. Minor formatting fixes, including semicolon consistency.

These changes improve modularity, compatibility, and maintainability across environments.